### PR TITLE
feat: stringify results in CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,5 +15,5 @@ parseChangelog(file, function (err, result) {
     process.exit(1)
   }
 
-  console.log(result)
+  console.log(JSON.stringify(result))
 })


### PR DESCRIPTION
when I use this tool in the CLI I'd like to have it piped to a json file.  In order to do this, the CLI needs to output properly formatted json instead of just the js object.