### PR TITLE
Protect against no current value

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,9 @@ function doParse (file) {
   return new Promise(function (resolve, reject) {
     lineReader.eachLine(file, cb, EOL).then(function () {
       // push last version into log
-      pushCurrent(data)
+      if (data.current) {
+        pushCurrent(data)
+      }
 
       // clean up description
       data.log.description = clean(data.log.description)


### PR DESCRIPTION
`pushCurrent` will attempt to access `data.current._private`. `data.current` is initially set to `null`. If `data.current` was not populated this access will fail.