### PR TITLE
feat: allow H1 version headers in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased Changes
+
+### Features
+
+- allow version headers in CHANGELOG to use either H1 (#) or H2 (##) headers (#14) - @eladb
+
 ## [2.5.1](https://github.com/ungoldman/changelog-parser/compare/v2.5.0...v2.5.1) - 2018-12-05
 
 ### Fixes

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function handleLine (line) {
   }
 
   // new version found!
-  if (line.match(/^## ?[^#]/)) {
+  if (line.match(/^##? ?[^#]/)) {
     if (this.current && this.current.title) pushCurrent(this)
 
     this.current = versionFactory()

--- a/test/CHANGELOG.md
+++ b/test/CHANGELOG.md
@@ -15,6 +15,12 @@ A cool description (optional).
 * Update API
 * Fix bug #1
 
+# 2.3.0 - 2018-12-18
+
+### Added
+
+- Some changelog generators such as [standard-version](https://github.com/conventional-changelog/standard-version) would produce H1s for major versions and H2s for minor versions. We want the parser to be able to parse both.
+
 ## 2.2.3-pre.1 - 2013-02-14
 
 ### Added

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,19 @@ var expected = {
         ]
       }
     },
+    { version: '2.3.0',
+      title: '2.3.0 - 2018-12-18',
+      'date': '2018-12-18',
+      body: '### Added' + EOL + EOL + '- Some changelog generators such as [standard-version](https://github.com/conventional-changelog/standard-version) would produce H1s for major versions and H2s for minor versions. We want the parser to be able to parse both.',
+      parsed: {
+        _: [
+          'Some changelog generators such as standard-version would produce H1s for major versions and H2s for minor versions. We want the parser to be able to parse both.'
+        ],
+        Added: [
+          'Some changelog generators such as standard-version would produce H1s for major versions and H2s for minor versions. We want the parser to be able to parse both.'
+        ]
+      }
+    },
     { version: '2.2.3-pre.1',
       title: '2.2.3-pre.1 - 2013-02-14',
       'date': '2013-02-14',


### PR DESCRIPTION
[conventional-changelog] currently produces H1 headers for major version
bumps and H2 headers for minor/patch bumps. This might change in the future
but it would help to relax the parser so it will be able to process
those types of headers as well.

Added unit test.

Fixes #14