### PR TITLE
fix: keep entries with whitespace-only headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ This will print the JSON object representing the change log to the terminal.
 
 Alternately you can run it without arguments and it will look for a `CHANGELOG.md` file in the working directory.
 
+## Migrating from 3.x
+
+4.0.0 is ESM-only. The API and output are otherwise unchanged.
+
+- **ESM**: `import parseChangelog from 'changelog-parser'`, or the named `import { parseChangelog }`.
+- **CommonJS**: a bare `require('changelog-parser')` no longer returns the function. On Node 22.12+, where `require()` of an ES module is supported, use `const { parseChangelog } = require('changelog-parser')`. On older Node, use a dynamic `import()`. Node 22.12+ is only needed for this path.
+- `body` and `description` are now always joined with `\n` rather than the OS line ending, so output no longer varies by platform.
+
 ## Standards
 
 This module assumes your change log is a [markdown](http://daringfireball.net/projects/markdown/syntax) file structured roughly like so:

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,9 +144,8 @@ function handleLine(state: ParseState, options: ChangelogOptions, line: string):
 
   // new version found!
   if (line.match(/^##? ?[^#]/)) {
-    // a previous entry with a title is finalized here; an empty-title entry
-    // (degenerate whitespace-only heading) is dropped, preserving prior behavior
-    if (state.current?.title) pushCurrent(state)
+    // finalize the previous entry, including empty-title ones, matching the end-of-input flush
+    if (state.current) pushCurrent(state)
 
     state.current = versionFactory()
     state.activeSubhead = null

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -92,13 +92,16 @@ test('does not duplicate a repeated subheading within a version', async () => {
   assert.deepStrictEqual(result.versions[0].parsed.Added, ['- a', '- b'])
 })
 
-test('drops a mid-stream entry with an empty (whitespace-only) heading', async () => {
-  // Documents existing behavior: a heading that trims to an empty title is not
-  // finalized when the next heading appears.
+test('keeps an entry with an empty (whitespace-only) heading', async () => {
+  // A heading that trims to an empty title still yields an entry, rather than
+  // being silently dropped when the next heading appears.
   const result = await parseChangelog({ text: '# t\n\n##  \n* a\n\n## 1.0.0\n* b\n' })
   assert.deepStrictEqual(
-    result.versions.map((v) => v.version),
-    ['1.0.0']
+    result.versions.map((v) => ({ version: v.version, title: v.title, items: v.parsed._ })),
+    [
+      { version: null, title: '', items: ['a'] },
+      { version: '1.0.0', title: '1.0.0', items: ['b'] }
+    ]
   )
 })
 


### PR DESCRIPTION
Keeps changelog entries whose heading trims to an empty title instead of dropping them when the next heading appears. Also adds a Migrating from 3.x section to the README for the 4.0.0 ESM-only change.

## Changes
- Finalize the previous entry on any new heading (matching the end-of-input flush), so an empty-title entry is kept with its body and parsed items
- Update the characterization test to assert the entry is kept
- README: add Migrating from 3.x (ESM and CJS import, the Node 22.12 require() path, the body and description \n change)

## Verification
- npm test: 17 tests green
- npm run coverage: 100%

Targets the held 4.0.0 release (#57).
