### PR TITLE
fix: ignore HTML comments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ const date = /.*[ ]\(?(\d\d?\d?\d?[-/.]\d\d?[-/.]\d\d?\d?\d?)\)?.*/
 const subhead = /^###/
 const listitem = /^[*-]/
 const lineSplit = /\r\n?|\n/
+const htmlComment = /<!--[\s\S]*?-->/g
 
 interface ParseState {
   log: Changelog
@@ -107,13 +108,16 @@ async function parse(options: ChangelogOptions): Promise<Changelog> {
       ? options.text
       : await readFile(options.filePath as string, 'utf8')
 
+  // strip HTML comments (single and multi-line) so they are not parsed as content
+  const content = text.replace(htmlComment, '')
+
   const state: ParseState = {
     log: { versions: [] },
     current: null,
     activeSubhead: null
   }
 
-  for (const line of text.split(lineSplit)) {
+  for (const line of content.split(lineSplit)) {
     handleLine(state, options, line)
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -92,6 +92,26 @@ test('does not duplicate a repeated subheading within a version', async () => {
   assert.deepStrictEqual(result.versions[0].parsed.Added, ['- a', '- b'])
 })
 
+test('ignores HTML comments (#33)', async () => {
+  const text = [
+    '# Changelog',
+    '<!-- top-level comment -->',
+    '',
+    '## 1.0.0',
+    '<!--',
+    'multi-line comment',
+    '-->',
+    '* real item',
+    ''
+  ].join('\n')
+  const result = await parseChangelog({ text, removeMarkdown: false })
+
+  assert.equal(result.versions.length, 1)
+  assert.deepStrictEqual(result.versions[0].parsed._, ['* real item'])
+  assert.ok(!('description' in result))
+  assert.ok(!result.versions[0].body.includes('comment'))
+})
+
 test('keeps an entry with an empty (whitespace-only) heading', async () => {
   // A heading that trims to an empty title still yields an entry, rather than
   // being silently dropped when the next heading appears.


### PR DESCRIPTION
Strips HTML comments before parsing so they are no longer treated as entries, descriptions, or list items.

## Changes
- Remove `<!-- ... -->` (single and multi-line) from the source before splitting into lines
- Add a test for standalone and multi-line comments

## Verification
- npm test: 18 tests green
- npm run coverage: 100%

Inline comments mid-line leave the surrounding spaces behind; comments on their own line or as a block (the common case) are removed cleanly.

Closes #33. Targets the held 4.0.0 release (#57).
