### PR TITLE
fix: handle square brackets in entries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,12 @@ const subhead = /^###/
 const listitem = /^[*-]/
 const lineSplit = /\r\n?|\n/
 const htmlComment = /<!--[\s\S]*?-->/g
+// a `[token]` whose `]` is not immediately followed by `(` or `[`, i.e. not an inline or full reference link
+const standaloneBracket = /\[([^\][]*)\](?![([])/g
+// a link reference definition line: `[label]: url`
+const linkDefinition = /^\[([^[\]]+)\] *?:/
+const bracketOpen = String.fromCharCode(0)
+const bracketClose = String.fromCharCode(1)
 
 interface ParseState {
   log: Changelog
@@ -110,6 +116,14 @@ async function parse(options: ChangelogOptions): Promise<Changelog> {
 
   // strip HTML comments (single and multi-line) so they are not parsed as content
   const content = text.replace(htmlComment, '')
+  const lines = content.split(lineSplit)
+
+  // link reference definitions can appear anywhere in the document, so collect them first
+  const definedLabels = new Set<string>()
+  for (const line of lines) {
+    const def = linkDefinition.exec(line)
+    if (def) definedLabels.add(normalizeLabel(def[1]))
+  }
 
   const state: ParseState = {
     log: { versions: [] },
@@ -117,8 +131,8 @@ async function parse(options: ChangelogOptions): Promise<Changelog> {
     activeSubhead: null
   }
 
-  for (const line of content.split(lineSplit)) {
-    handleLine(state, options, line)
+  for (const line of lines) {
+    handleLine(state, options, line, definedLabels)
   }
 
   // push last version into log
@@ -136,7 +150,12 @@ async function parse(options: ChangelogOptions): Promise<Changelog> {
 }
 
 /** Handles a single line, mutating the parse state as needed. */
-function handleLine(state: ParseState, options: ChangelogOptions, line: string): void {
+function handleLine(
+  state: ParseState,
+  options: ChangelogOptions,
+  line: string,
+  definedLabels: Set<string>
+): void {
   // skip line if it's a link label
   if (line.match(/^\[[^[\]]*\] *?:/)) return
 
@@ -183,7 +202,7 @@ function handleLine(state: ParseState, options: ChangelogOptions, line: string):
 
     // handle case where current line is a 'list item':
     if (listitem.exec(line)) {
-      const log = options.removeMarkdown ? removeMarkdown(line) : line
+      const log = options.removeMarkdown ? stripMarkdown(line, definedLabels) : line
       // add line to 'catch all' array
       state.current.parsed._.push(log)
 
@@ -213,6 +232,29 @@ function pushCurrent(state: ParseState): void {
   const current = state.current as ChangelogVersion
   current.body = clean(current.body)
   state.log.versions.push(current)
+}
+
+// markdown reference labels are case-insensitive and collapse internal whitespace
+function normalizeLabel(label: string): string {
+  return label.trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+/**
+ * Strip markdown from a list item. A standalone `[token]` (not part of an inline or full
+ * reference link) is resolved against the document's link reference definitions: if `token`
+ * is defined elsewhere it is a shortcut reference link and renders as its text, so the
+ * brackets are dropped; otherwise it is literal text and is preserved. Preserving also
+ * sidesteps a remove-markdown bug where a standalone `[token]` followed by `(` is consumed
+ * as the next link's text.
+ */
+function stripMarkdown(line: string, definedLabels: Set<string>): string {
+  // fast path: with no brackets there is nothing to protect or resolve
+  if (!line.includes('[')) return removeMarkdown(line)
+  const protectedLine = line.replace(standaloneBracket, (_match, inner) => {
+    if (definedLabels.has(normalizeLabel(inner))) return inner
+    return `${bracketOpen}${inner}${bracketClose}`
+  })
+  return removeMarkdown(protectedLine).replaceAll(bracketOpen, '[').replaceAll(bracketClose, ']')
 }
 
 function clean(str: string | undefined): string {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { test } from 'node:test'
 import fc from 'fast-check'
+import removeMarkdown from 'remove-markdown'
 import parseChangelog from '../src/index.ts'
 import expected from './fixtures/expected.ts'
 import removeMarkdownExpected from './fixtures/remove-markdown-expected.ts'
@@ -170,5 +171,41 @@ test('property: every version heading yields one entry, regardless of line endin
         }
       }
     )
+  )
+})
+
+test('resolves standalone brackets against link definitions (#46)', async () => {
+  const text = [
+    '# Changelog',
+    '',
+    '## 1.0.0',
+    '* add some new stuff [incomplete] ([abc](https://x/abc))',
+    '* see [defined] for details',
+    '* keep [undefined] literal',
+    '',
+    '[defined]: https://example.com'
+  ].join('\n')
+  const result = await parseChangelog({ text })
+
+  assert.deepStrictEqual(result.versions[0].parsed._, [
+    // [incomplete] has no definition, so it stays literal; the real [abc](url) link strips
+    'add some new stuff [incomplete] (abc)',
+    // [defined] resolves to a definition below, so it is a link and renders as its text
+    'see defined for details',
+    // [undefined] has no definition, so it stays literal
+    'keep [undefined] literal'
+  ])
+})
+
+test('property: stripping bracket-free items matches remove-markdown', async () => {
+  const safe = fc
+    .string()
+    .filter((s) => !s.includes('[') && !s.includes(']') && !s.includes('\n') && !s.includes('\r'))
+
+  await fc.assert(
+    fc.asyncProperty(safe, async (item) => {
+      const result = await parseChangelog({ text: `# t\n\n## 1.0.0\n* ${item}\n` })
+      assert.equal(result.versions[0].parsed._[0], removeMarkdown(`* ${item}`))
+    })
   )
 })


### PR DESCRIPTION
Fixes how square-bracket text in list items is handled, addressing the mangling reported in #46.

A standalone `[token]` (one that is not part of an inline `[text](url)` or full reference `[text][ref]` link) is now resolved against the document's link reference definitions:

- defined elsewhere as `[token]: url` → it is a shortcut reference link, so it renders as its text (`token`)
- not defined → kept literal (`[token]`)

This also fixes remove-markdown consuming a standalone `[token]` that is followed by a real link, e.g. the Lerna-style `[incomplete] ([sha](url))` in the issue.

## Changes
- Pre-scan the document for `[label]:` definitions (they can appear anywhere, before or after use) and match labels case-insensitively, per CommonMark
- Resolve or preserve standalone brackets in list items accordingly; bracket-free items pass straight through unchanged
- Add tests for the resolution cases plus a property test asserting bracket-free items match remove-markdown

## Verification
- npm test: 19 tests green
- npm run coverage: 100%

Addresses the `[]` parsing in #46. The separate "no document title, so a `#` version heading is read as the title" case raised in that thread ([comment](https://github.com/ungoldman/changelog-parser/issues/46#issuecomment-3418560812)) is queued as its own fix. Targets the held 4.0.0 release (#57).
