### PR TITLE
fix: parse untitled changelogs and standard-version patch headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Version headings may be `#`, `##`, or `###`, with or without a `[bracketed]` and
 
 ## Usage
 
-This module is [ESM-only](https://nodejs.org/api/esm.html) and requires Node.js >= 22.12. It exports a single function, available as both a default and a named export. It supports both callbacks and promises.
+This module is [ESM-only](https://nodejs.org/api/esm.html). It exports a single function, available as both a default and a named export. It supports both callbacks and promises.
 
 ```js
 import parseChangelog from 'changelog-parser'

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Change log parser for node.
 npm install changelog-parser
 ```
 
+## Supported formats
+
+`changelog-parser` parses these common changelog formats:
+
+- [Keep a Changelog](https://keepachangelog.com/): `## [x.y.z] - YYYY-MM-DD` headings with `### Added` / `### Changed` / etc. sections
+- [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog): `## [x.y.z](compare) (date)` headings, with or without a top-level title
+- [standard-version](https://github.com/conventional-changelog/standard-version): heading level set by release type (`#` major, `##` minor, `###` patch)
+- [release-please](https://github.com/googleapis/release-please): `## [x.y.z](compare) (date)` headings with a `### ⚠ BREAKING CHANGES` section
+
+Version headings may be `#`, `##`, or `###`, with or without a `[bracketed]` and/or linked version, and with a date in several formats. A document title (the first `# Heading` that is not itself a version) is optional.
+
 ## Usage
 
 This module is [ESM-only](https://nodejs.org/api/esm.html) and requires Node.js >= 22.12. It exports a single function, available as both a default and a named export. It supports both callbacks and promises.

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,10 @@ const date = /.*[ ]\(?(\d\d?\d?\d?[-/.]\d\d?[-/.]\d\d?\d?\d?)\)?.*/
 const subhead = /^###/
 const listitem = /^[*-]/
 const lineSplit = /\r\n?|\n/
+// a heading (1-3 `#`) whose text starts with a version-like token: optional `[`/`v`, then a digit.
+// conventional-changelog and standard-version encode the bump level in the heading (# major,
+// ## minor, ### patch), so this tells a version heading apart from the title and from `### Section`.
+const versionHeading = /^#{1,3} ?\[?v?\d+\.\d/
 const htmlComment = /<!--[\s\S]*?-->/g
 // a `[token]` whose `]` is not immediately followed by `(` or `[`, i.e. not an inline or full reference link
 const standaloneBracket = /\[([^\][]*)\](?![([])/g
@@ -159,14 +163,14 @@ function handleLine(
   // skip line if it's a link label
   if (line.match(/^\[[^[\]]*\] *?:/)) return
 
-  // set title if it's there
-  if (!state.log.title && line.match(/^# ?[^#]/)) {
+  // set title if it's there: the first H1 that is not itself a version heading
+  if (!state.log.title && line.match(/^# ?[^#]/) && !versionHeading.test(line)) {
     state.log.title = line.substring(1).trim()
     return
   }
 
-  // new version found!
-  if (line.match(/^##? ?[^#]/)) {
+  // new version found! H1/H2 by level, plus a version-like H3 (conventional-changelog patch)
+  if (line.match(/^##? ?[^#]/) || versionHeading.test(line)) {
     // finalize the previous entry, including empty-title ones, matching the end-of-input flush
     if (state.current) pushCurrent(state)
 
@@ -176,7 +180,7 @@ function handleLine(
     const semverMatch = semver.exec(line)
     if (semverMatch) state.current.version = semverMatch[1]
 
-    state.current.title = line.substring(2).trim()
+    state.current.title = line.replace(/^#+\s*/, '').trim()
 
     const dateMatch = date.exec(state.current.title)
     if (dateMatch) state.current.date = dateMatch[1]

--- a/test/fixtures/standards/conventional-changelog.md
+++ b/test/fixtures/standards/conventional-changelog.md
@@ -1,0 +1,15 @@
+## [1.2.0](https://example.com/compare/v1.1.0...v1.2.0) (2024-03-15)
+
+### Features
+
+* add a `format` option ([abc1234](https://example.com/commit/abc1234))
+
+### Bug Fixes
+
+* handle empty input ([def5678](https://example.com/commit/def5678))
+
+# [1.0.0](https://example.com/compare/v0.9.0...v1.0.0) (2024-01-02)
+
+### Features
+
+* first stable release

--- a/test/fixtures/standards/keepachangelog.md
+++ b/test/fixtures/standards/keepachangelog.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0] - 2023-03-05
+
+### Added
+
+- A new option.
+
+### Fixed
+
+- A crash on empty input.
+
+## [1.0.0] - 2023-01-01
+
+### Added
+
+- First release.
+
+[unreleased]: https://example.com/compare/v1.1.0...HEAD
+[1.1.0]: https://example.com/compare/v1.0.0...v1.1.0
+[1.0.0]: https://example.com/releases/v1.0.0

--- a/test/fixtures/standards/release-please.md
+++ b/test/fixtures/standards/release-please.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## [2.0.0](https://example.com/compare/v1.1.0...v2.0.0) (2024-03-15)
+
+
+### ⚠ BREAKING CHANGES
+
+* drops support for Node 18
+
+### Features
+
+* a shiny thing ([#42](https://example.com/issues/42)) ([abc1234](https://example.com/commit/abc1234))
+
+### Bug Fixes
+
+* a fix ([def5678](https://example.com/commit/def5678))
+
+## [1.1.0](https://example.com/compare/v1.0.0...v1.1.0) (2024-01-02)
+
+
+### Features
+
+* an earlier feature

--- a/test/fixtures/standards/standard-version.md
+++ b/test/fixtures/standards/standard-version.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## [1.1.0](https://example.com/compare/v1.0.1...v1.1.0) (2024-03-15)
+
+### Features
+
+* a minor feature
+
+### [1.0.1](https://example.com/compare/v1.0.0...v1.0.1) (2024-02-01)
+
+### Bug Fixes
+
+* a patch fix
+
+# [1.0.0](https://example.com/compare/v0.9.0...v1.0.0) (2024-01-02)
+
+### Features
+
+* a major feature

--- a/test/formats.test.ts
+++ b/test/formats.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import parseChangelog from '../src/index.ts'
+
+const dir = join(import.meta.dirname, 'fixtures', 'standards')
+const parse = (name: string) => parseChangelog({ text: readFileSync(join(dir, name), 'utf8') })
+
+test('Keep a Changelog', async () => {
+  const r = await parse('keepachangelog.md')
+  assert.equal(r.title, 'Changelog')
+  assert.deepStrictEqual(
+    r.versions.map((v) => v.version),
+    [null, '1.1.0', '1.0.0']
+  )
+  assert.deepStrictEqual(
+    r.versions.map((v) => v.date),
+    [null, '2023-03-05', '2023-01-01']
+  )
+  assert.deepStrictEqual(Object.keys(r.versions[1].parsed), ['_', 'Added', 'Fixed'])
+  assert.deepStrictEqual(r.versions[1].parsed.Added, ['A new option.'])
+})
+
+test('conventional-changelog (no title, mixed # and ##)', async () => {
+  const r = await parse('conventional-changelog.md')
+  // no document title, and the H1 major version is not stolen as the title
+  assert.equal(r.title, undefined)
+  assert.deepStrictEqual(
+    r.versions.map((v) => v.version),
+    ['1.2.0', '1.0.0']
+  )
+  assert.deepStrictEqual(
+    r.versions.map((v) => v.date),
+    ['2024-03-15', '2024-01-02']
+  )
+  assert.deepStrictEqual(Object.keys(r.versions[0].parsed), ['_', 'Features', 'Bug Fixes'])
+  // the code span and commit link are stripped from the item
+  assert.deepStrictEqual(r.versions[0].parsed.Features, ['add a format option (abc1234)'])
+})
+
+test('standard-version (# major, ## minor, ### patch)', async () => {
+  const r = await parse('standard-version.md')
+  assert.equal(r.title, 'Changelog')
+  // the ### patch heading is parsed as a version, not as a section
+  assert.deepStrictEqual(
+    r.versions.map((v) => v.version),
+    ['1.1.0', '1.0.1', '1.0.0']
+  )
+  assert.deepStrictEqual(
+    r.versions.map((v) => v.date),
+    ['2024-03-15', '2024-02-01', '2024-01-02']
+  )
+  assert.deepStrictEqual(r.versions[1].parsed['Bug Fixes'], ['a patch fix'])
+})
+
+test('release-please', async () => {
+  const r = await parse('release-please.md')
+  assert.equal(r.title, 'Changelog')
+  assert.deepStrictEqual(
+    r.versions.map((v) => v.version),
+    ['2.0.0', '1.1.0']
+  )
+  assert.deepStrictEqual(Object.keys(r.versions[0].parsed), [
+    '_',
+    '⚠ BREAKING CHANGES',
+    'Features',
+    'Bug Fixes'
+  ])
+  assert.deepStrictEqual(r.versions[0].parsed['Bug Fixes'], ['a fix (def5678)'])
+})


### PR DESCRIPTION
Fixes how version headings are classified so two more changelog variants parse correctly, and codifies the common formats with fixtures and docs.

## What was broken
- Changelogs with no document title lost their first H1 version (it was taken as the title). This affects conventional-changelog output without a title, e.g. vitepress.
- standard-version patch releases written as `### [x.y.z]` were parsed as sections rather than versions, and dropped.

Keep a Changelog, titled conventional-changelog, and release-please already parsed correctly; this also adds fixtures locking all four.

## Changes
- Classify version headings by content: an H1 that is itself a version is not taken as the title, and a version-like `###` is a version, not a section. `#` and `##` stay versions by level, so `## Unreleased` is unaffected.
- Add a fixture per format under `test/fixtures/standards/` with tests on titles, version lists, dates, and sections
- Add a Supported formats section to the README

## Verification
- npm test: 24 tests green
- npm run coverage: 100%
- Confirmed against real changelogs: vitepress (recovers the dropped H1 version) and standard-version's own (recovers 7 dropped `### [x.y.z]` patch versions)

Handles the no-title `# version` case raised in #46 ([comment](https://github.com/ungoldman/changelog-parser/issues/46#issuecomment-3418560812)). Targets the held 4.0.0 release (#57).
