### PR TITLE
docs: add agent guidelines and coding conventions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Guidelines
+
+- install: `npm install`
+- test: `npm test`
+- coverage: `npm run coverage`
+
+Release automated by `.github/workflows/release.yml`, do not alter version.
+
+Follow all coding and commit conventions in `CONTRIBUTING.md`.
+
+Omit AI attribution in commits (Co-authored-by). Polluting git history with AI advertising is not allowed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 This project is intended to be a safe, welcoming space for collaboration.
 
-All contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+All contributors are expected to adhere to the [Contributor Covenant](https://contributor-covenant.org) code of conduct.
 
 Thank you for being kind to each other!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,12 @@ This project welcomes any kind of contribution! Here are a few suggestions:
 - **Copy editing**: fix typos, clarify language, and generally improve the quality of the content.
 - **Formatting**: help keep content easy to read with consistent formatting.
 - **Code**: help maintain and improve the project codebase.
+
+## Coding Guidelines
+
+- Commits should be atomic and adhere to [conventional commit](https://conventionalcommits.org) standards.
+- Commit messages should be short (`<topic>: <action>`, 50 char max), and commit bodies only included when necessary for complex changes (72 char max).
+- Breaking changes are discouraged, and require a `BREAKING CHANGE:` footer in the commit body explaining the change.
+- Types and interfaces should be inlined unless they're absolutely necessary for exporting or testing.
+- Avoid unnecessary code comments, and keep necessary ones trim.
+- All changes should maintain the test coverage gate (100%).


### PR DESCRIPTION
Adds the agent-facing docs and coding guidelines that were missing here: CONTRIBUTING.md now states the commit conventions and the coverage gate, and AGENTS.md (with CLAUDE.md symlinked to it) gives agents the ground rules, including the do-not-alter-version warning the release automation depends on.

## Changes
- CONTRIBUTING.md: add Coding Guidelines (conventional commits, breaking-change policy, coverage gate)
- add AGENTS.md; symlink CLAUDE.md to it
- CONTRIBUTING.md: switch the Contributor Covenant link to https
- tests.yml: cancel superseded runs on the same ref